### PR TITLE
fix: wallet image saving on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+-   Resolved an issue with saving generated wallets on iOS ([#22])
+
 ## 3.0.0 - 25-07-2019
 
 ### Added
 
-- New ARK Paper Wallet version built from scratch, made with Vue.JS and TailwindCSS
+-   New ARK Paper Wallet version built from scratch, made with Vue.JS and TailwindCSS
+
+[unreleased]: https://github.com/ARKEcosystem/paper-wallet/compare/master...develop
+[#22]: https://github.com/ARKEcosystem/paper-wallet/pull/22

--- a/src/views/Wallet.vue
+++ b/src/views/Wallet.vue
@@ -216,7 +216,7 @@ export default class Wallet extends Vue {
             windowHeight: 800,
         }).then(canvas => {
             const link = document.createElement("a");
-            link.href = canvas.toDataURL("image/jpeg").replace("image/jpeg", "image/octet-stream");
+            link.href = canvas.toDataURL("image/jpeg");
             link.download = `ark-paper-wallet-${this.wallet.address}.jpg`;
             link.click();
 


### PR DESCRIPTION
Paper-Wallet currently does not save images correctly in iOS.

This PR allows images to be saved successfully in iOS by removing:

```js
/* Wallet.vue - ln# 219 */
.replace("image/jpeg", "image/octet-stream")
```
This PR also updates the changelog accordingly.

## What kind of change does this PR introduce?

- [x] Bugfix

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Does this PR release a new version?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, _not_ the `master` branch
- [x] All tests are passing
- [ ] New/updated tests are included
